### PR TITLE
feat: add ensouled hellhound head for pray xp

### DIFF
--- a/src/main/resources/item_xp_data.json
+++ b/src/main/resources/item_xp_data.json
@@ -111,6 +111,11 @@
       "skill": "prayer"
     },
     {
+      "id": 26997,
+      "xp": 1200,
+      "skill": "prayer"
+    },
+    {
       "id": 526,
       "xp": 15.7,
       "skill": "prayer"


### PR DESCRIPTION
According to the wiki, you get 1200 prayer exp for this new ensouled head: https://oldschool.runescape.wiki/w/Ensouled_hellhound_head#Item

This looks like the right item id according to the RL client: https://github.com/runelite/runelite/blob/1ca54e0f75a519c3fe3dae3761644656082a31e6/runelite-api/src/main/java/net/runelite/api/ItemID.java#L12669