### PR TITLE
Add missing items to xp data

### DIFF
--- a/src/main/resources/item_xp_data.json
+++ b/src/main/resources/item_xp_data.json
@@ -181,6 +181,46 @@
       "skill": "prayer"
     },
     {
+      "id": 5076,
+      "xp": 100,
+      "skill": "prayer"
+    }, 
+    {
+      "id": 5077,
+      "xp": 100,
+      "skill": "prayer"
+    }, 
+    {
+      "id": 5078,
+      "xp": 100,
+      "skill": "prayer"
+    },
+    {
+      "id": 25766,
+      "xp": 30,
+      "skill": "prayer"
+    },
+    {
+      "id": 25769,
+      "xp": 75,
+      "skill": "prayer"
+    },
+    {
+      "id": 25772,
+      "xp": 195,
+      "skill": "prayer"
+    },
+    {
+      "id": 25775,
+      "xp": 255,
+      "skill": "prayer"
+    },
+    {
+      "id": 25778,
+      "xp": 330,
+      "skill": "prayer"
+    },
+    {
       "id": 2349,
       "xp": 12.5,
       "skill": "smithing"
@@ -228,6 +268,16 @@
     {
       "id": 451,
       "xp": 125,
+      "skill": "smithing"
+    },
+    {
+      "id": 442,
+      "xp": 13.7,
+      "skill": "smithing"
+    },
+    {
+      "id": 447,
+      "xp": 30,
       "skill": "smithing"
     },
     {
@@ -736,6 +786,11 @@
       "skill": "fletching"
     },
     {
+      "id": 11874,
+      "xp": 10,
+      "skill": "fletching"
+    },
+    {
       "id": 1511,
       "xp": 40,
       "skill": "firemaking"
@@ -948,6 +1003,16 @@
     {
       "id": 9978,
       "xp": 62,
+      "skill": "cooking"
+    },
+    {
+      "id": 363,
+      "xp": 130,
+      "skill": "cooking"
+    },
+    {
+      "id": 341,
+      "xp": 75,
       "skill": "cooking"
     },
     {


### PR DESCRIPTION
Added these items to the xp data json: 
* Silver ore (smithing)
* Mithril ore (smithing)
* Bird's eggs (prayer - 3 types)
* Ashes (prayer - 5 types: fiendish, vile, malicious, abyssal, infernal)
* Raw cod (cooking)
* Raw bass (cooking)
* Broad arrowheads (fletching)

Addresses #17 as well as some items I've noticed were missing as I've been using the plugin